### PR TITLE
browser popup fixes

### DIFF
--- a/packages/keepkey-desktop-app/headers/csps/defi/yearn.ts
+++ b/packages/keepkey-desktop-app/headers/csps/defi/yearn.ts
@@ -21,6 +21,8 @@ export const csp: Csp = {
     'https://meta.yearn.network/vaults/1/all',
     // @yfi/sdk@1.0.12: https://github.com/yearn/yearn-sdk/blob/0a85ae7be734ba594b8b7e4a290e631610a3b399/src/services/assets.ts#L13
     'https://api.github.com/repos/yearn/yearn-assets/',
+    // @yfi/sdk@1.0.12: https://github.com/yearn/yearn-sdk/blob/0a85ae7be734ba594b8b7e4a290e631610a3b399/src/services/vision.ts#L32
+    'https://d28fcsszptni1s.cloudfront.net/v1/chains/',
   ],
   'img-src': [
     'https://rawcdn.githack.com/yearn/yearn-assets/',

--- a/packages/keepkey-desktop-app/headers/csps/electron.ts
+++ b/packages/keepkey-desktop-app/headers/csps/electron.ts
@@ -1,0 +1,5 @@
+import type { Csp } from '../types'
+
+export const csp: Csp = {
+  'connect-src': ['node:'],
+}

--- a/packages/keepkey-desktop-app/headers/csps/pioneer.ts
+++ b/packages/keepkey-desktop-app/headers/csps/pioneer.ts
@@ -1,0 +1,5 @@
+import type { Csp } from '../types'
+
+export const csp: Csp = {
+  'connect-src': ['https://pioneers.dev'],
+}

--- a/packages/keepkey-desktop-app/headers/csps/plugins/walletConnectToDapps.ts
+++ b/packages/keepkey-desktop-app/headers/csps/plugins/walletConnectToDapps.ts
@@ -1,5 +1,6 @@
 import type { Csp } from '../../types'
 
 export const csp: Csp = {
+  'connect-src': ['wss://relay.walletconnect.com'],
   'img-src': ['https://registry.walletconnect.com', 'https://explorer-api.walletconnect.com'],
 }

--- a/packages/keepkey-desktop-app/headers/csps/wallets/walletconnect.ts
+++ b/packages/keepkey-desktop-app/headers/csps/wallets/walletconnect.ts
@@ -5,7 +5,7 @@ export const csp: Csp = {
     '*',
     'wss://*.bridge.walletconnect.org/',
     'https://registry.walletconnect.com/api/v2/wallets',
-    "https://api.etherscan.io"
+    'https://api.etherscan.io',
   ],
-  'img-src': ['https://imagedelivery.net/', 'https://registry.walletconnect.com/api/v2/logo/', "*"],
+  'img-src': ['https://imagedelivery.net/', 'https://registry.walletconnect.com/api/v2/logo/', '*'],
 }

--- a/packages/keepkey-desktop-app/src/App.tsx
+++ b/packages/keepkey-desktop-app/src/App.tsx
@@ -5,7 +5,7 @@ import type { PairingProps } from 'components/Modals/Pair/types'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { PinMatrixRequestType } from 'context/WalletProvider/KeepKey/KeepKeyTypes'
 import { useKeepKey } from 'context/WalletProvider/KeepKeyProvider'
-import { ipcListeners, ipcRenderer } from 'electron-shim'
+import { ipcListeners } from 'electron-shim'
 import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { useWalletConnect } from 'plugins/walletConnectToDapps/WalletConnectBridgeContext'
@@ -301,7 +301,7 @@ export const App = () => {
     // inform the electron process we are ready to receive ipc messages
     const { port1, port2 } = new MessageChannel()
     Comlink.expose(rendererIpc, port1)
-    ipcRenderer.postMessage('@app/register-render-listeners', undefined, [port2])
+    window.postMessage({ type: '@app/register-render-listeners', payload: port2 }, '*', [port2])
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/packages/keepkey-desktop-app/src/Routes/RoutesCommon.tsx
+++ b/packages/keepkey-desktop-app/src/Routes/RoutesCommon.tsx
@@ -1,6 +1,3 @@
-import { WalletConnectToDapps } from 'plugins/walletConnectToDapps/WalletConnectToDapps'
-import { FaFlag, FaGlobe, FaBuromobelexperte, FaPlug, FaLock } from 'react-icons/fa'
-// import { IoSwapVertical } from 'react-icons/io5'
 import { AccountsIcon } from 'components/Icons/Accounts'
 import { AssetsIcon } from 'components/Icons/Assets'
 import { DashboardIcon } from 'components/Icons/Dashboard'
@@ -14,20 +11,17 @@ import { Asset } from 'pages/Assets/Asset'
 import { Assets } from 'pages/Assets/Assets'
 import { AssetTxHistory } from 'pages/Assets/AssetTxHistory'
 import { KeepkeyAsset } from 'pages/Assets/KeepkeyAsset'
+import { Authenticator } from 'pages/Authenticator/Authenticator'
 import { Browser } from 'pages/Browser/Browser'
 import { Dashboard } from 'pages/Dashboard/Dashboard'
-// import { Overview } from 'pages/Defi/views/Overview'
-import { Flags } from 'pages/Flags/Flags'
-// import { Leaderboard } from 'pages/Leaderboard/Leaderboard'
 import { PairingDetails } from 'pages/Pairings/PairingDetails'
 import { Pairings } from 'pages/Pairings/Pairings'
-// import { Trade } from 'pages/Trade/Trade'
 import { TransactionHistory } from 'pages/TransactionHistory/TransactionHistory'
-import { IoSwapVertical } from 'react-icons/io5'
+import { WalletConnectToDapps } from 'plugins/walletConnectToDapps/WalletConnectToDapps'
+import { FaBuromobelexperte, FaGlobe, FaLock, FaPlug } from 'react-icons/fa'
 
 import type { Route as NestedRoute } from './helpers'
 import { RouteCategory } from './helpers'
-import { Authenticator } from 'pages/Authenticator/Authenticator'
 
 export const routes: NestedRoute[] = [
   {
@@ -44,14 +38,6 @@ export const routes: NestedRoute[] = [
     icon: <FaBuromobelexperte />,
     category: RouteCategory.Wallet,
   },
-  //@TODO move to flag
-  // {
-  //   path: '/leaderboard',
-  //   label: 'Leaderboard',
-  //   icon: <IoSwapVertical />,
-  //   main: Leaderboard,
-  //   category: RouteCategory.Wallet,
-  // },
   {
     path: '/transaction-history',
     label: 'navBar.transactionHistory',
@@ -66,13 +52,6 @@ export const routes: NestedRoute[] = [
     category: RouteCategory.Explore,
     main: Browser,
   },
-  // {
-  //   path: '/trade',
-  //   label: 'navBar.trade',
-  //   icon: <IoSwapVertical />,
-  //   main: Trade,
-  //   category: RouteCategory.Explore,
-  // },
   {
     path: '/pairings',
     label: 'navBar.pairings',

--- a/packages/keepkey-desktop-app/src/components/Layout/Header/NavBar/MainNavLink.tsx
+++ b/packages/keepkey-desktop-app/src/components/Layout/Header/NavBar/MainNavLink.tsx
@@ -1,9 +1,8 @@
 import type { ButtonProps } from '@chakra-ui/react'
-import { Box, Button, forwardRef, Tooltip, useMediaQuery } from '@chakra-ui/react'
+import { Button, forwardRef, Tooltip } from '@chakra-ui/react'
 import { memo } from 'react'
 import type { NavLinkProps } from 'react-router-dom'
 import { useLocation } from 'react-router-dom'
-import { breakpoints } from 'theme/theme'
 
 type SidebarLinkProps = {
   href?: string
@@ -14,22 +13,26 @@ type SidebarLinkProps = {
 } & ButtonProps
 
 export const MainNavLink = memo(
-  forwardRef<SidebarLinkProps, 'div'>(({ isCompact = true, ...rest }: SidebarLinkProps, ref) => {
-    const { href, label } = rest
-    const location = useLocation()
-    const active = location?.pathname.includes(href ?? '')
-    return (
-      <Tooltip label={label} placement='top'>
-        <Button
-          width='full'
-          justifyContent={'center'}
-          variant='nav-link'
-          isActive={href ? active : false}
-          minWidth={'auto'}
-          ref={ref}
-          {...rest}
-        />
-      </Tooltip>
-    )
-  }),
+  forwardRef<SidebarLinkProps, 'div'>(
+    ({ isCompact = true, leftIcon, ...rest }: SidebarLinkProps, ref) => {
+      const { href, label } = rest
+      const location = useLocation()
+      const active = location?.pathname.includes(href ?? '')
+      return (
+        <Tooltip label={label} placement='top'>
+          <Button
+            width='full'
+            justifyContent={'center'}
+            variant='nav-link'
+            isActive={href ? active : false}
+            minWidth={'auto'}
+            ref={ref}
+            {...rest}
+          >
+            {leftIcon}
+          </Button>
+        </Tooltip>
+      )
+    },
+  ),
 )

--- a/packages/keepkey-desktop-app/src/components/Layout/Header/NavBar/NavBar.tsx
+++ b/packages/keepkey-desktop-app/src/components/Layout/Header/NavBar/NavBar.tsx
@@ -8,7 +8,7 @@ import { union } from 'lodash'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Link as ReactRouterLink } from 'react-router-dom'
-import type { Route } from 'Routes/helpers'
+import type { Route, RouteCategory } from 'Routes/helpers'
 import { routes } from 'Routes/RoutesCommon'
 
 import { MainNavLink } from './MainNavLink'
@@ -27,31 +27,18 @@ export const NavBar = ({ isCompact, onClick, ...rest }: NavBarProps) => {
     state: { wallet },
   } = useWallet()
 
-  const handleClick = (onClick?: () => void) => {
-    onClick && onClick()
-  }
-
   const [supportsAuthenticator, setSupportsAuthenticator] = useState(false)
 
   const navItemGroups = useMemo(() => {
     const allRoutes = union(routes, pluginRoutes).filter(route => !route.disable && !route.hide)
-    const groups = allRoutes.reduce(
-      (entryMap, currentRoute) =>
-        entryMap.set(currentRoute.category, [
-          ...(entryMap.get(currentRoute.category) || []),
-          currentRoute,
-        ]),
-      new Map(),
-    )
+    const groups = allRoutes.reduce((entryMap, currentRoute) => {
+      if (!entryMap.has(currentRoute.category)) entryMap.set(currentRoute.category, [])
+      entryMap.get(currentRoute.category)!.push(currentRoute)
+      return entryMap
+    }, new Map<RouteCategory | undefined, Route[]>())
 
-    const entries = Array.from(groups.entries())
-
-    const index = entries[1][1].findIndex((entry: any) => entry.path === '/authenticator')
-
-    !supportsAuthenticator && entries[1][1].splice(index, 1)
-
-    return entries
-  }, [pluginRoutes, supportsAuthenticator])
+    return Array.from(groups.entries())
+  }, [pluginRoutes])
 
   useEffect(() => {
     wallet?.getFirmwareVersion().then(version => {
@@ -62,28 +49,34 @@ export const NavBar = ({ isCompact, onClick, ...rest }: NavBarProps) => {
 
   return (
     <Flex width='full' flexDir='row' gap={6} {...rest}>
-      {navItemGroups.map((group, _id) => {
+      {navItemGroups.map((group, groupId) => {
         const [, values] = group
-        return values.map((item: Route, id: number) => (
-          <MainNavLink
-            isCompact={isCompact}
-            as={ReactRouterLink}
-            key={id}
-            leftIcon={item.icon}
-            href={item.path}
-            to={item.path}
-            size='lg'
-            onClick={onClick}
-            label={translate(item.label)}
-            aria-label={translate(item.label)}
-            data-test={`navigation-${item.label.split('.')[1]}-button`}
-          />
-        ))
+        return values
+          .filter((route: Route) => !route.hide)
+          .map((item: Route, itemId: number) => {
+            const disabled = item.path === '/authenticator' && !supportsAuthenticator
+            return (
+              <MainNavLink
+                isCompact={isCompact}
+                as={!disabled ? ReactRouterLink : undefined}
+                key={`${groupId}-${itemId}`}
+                leftIcon={item.icon}
+                href={item.path}
+                to={item.path}
+                size='lg'
+                onClick={onClick}
+                label={translate(item.label)}
+                disabled={disabled}
+                aria-label={translate(item.label)}
+                data-test={`navigation-${item.label.split('.')[1]}-button`}
+              />
+            )
+          })
       })}
       <MainNavLink
         isCompact={isCompact}
         size='sm'
-        onClick={() => handleClick(() => settings.open({}))}
+        onClick={() => settings.open({})}
         label={translate('common.settings')}
         leftIcon={<SettingsIcon />}
         data-test='navigation-settings-button'
@@ -98,7 +91,6 @@ export const NavBar = ({ isCompact, onClick, ...rest }: NavBarProps) => {
         leftIcon={<ChatIcon />}
         data-test='navigation-join-discord-button'
       />
-      {/* {isYatFeatureEnabled && <YatBanner isCompact={isCompact} />} */}
     </Flex>
   )
 }

--- a/packages/keepkey-desktop-app/src/components/Layout/Header/NavBar/NavBar.tsx
+++ b/packages/keepkey-desktop-app/src/components/Layout/Header/NavBar/NavBar.tsx
@@ -1,8 +1,6 @@
 import { ChatIcon, SettingsIcon } from '@chakra-ui/icons'
 import type { StackProps } from '@chakra-ui/react'
-import { Flex } from '@chakra-ui/react'
-import { Divider, Link, Stack, useColorModeValue } from '@chakra-ui/react'
-import { Text } from 'components/Text'
+import { Flex, Link } from '@chakra-ui/react'
 import { usePlugins } from 'context/PluginProvider/PluginProvider'
 import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -23,7 +21,6 @@ type NavBarProps = {
 export const NavBar = ({ isCompact, onClick, ...rest }: NavBarProps) => {
   const translate = useTranslate()
   const { routes: pluginRoutes } = usePlugins()
-  const groupColor = useColorModeValue('gray.300', 'gray.600')
   const { settings } = useModal()
 
   const {
@@ -65,7 +62,7 @@ export const NavBar = ({ isCompact, onClick, ...rest }: NavBarProps) => {
 
   return (
     <Flex width='full' flexDir='row' gap={6} {...rest}>
-      {navItemGroups.map((group, id) => {
+      {navItemGroups.map((group, _id) => {
         const [, values] = group
         return values.map((item: Route, id: number) => (
           <MainNavLink

--- a/packages/keepkey-desktop-app/src/components/Layout/Header/NavBar/NavBar.tsx
+++ b/packages/keepkey-desktop-app/src/components/Layout/Header/NavBar/NavBar.tsx
@@ -10,6 +10,7 @@ import { useTranslate } from 'react-polyglot'
 import { Link as ReactRouterLink } from 'react-router-dom'
 import type { Route, RouteCategory } from 'Routes/helpers'
 import { routes } from 'Routes/RoutesCommon'
+import * as semver from 'semver'
 
 import { MainNavLink } from './MainNavLink'
 
@@ -42,8 +43,7 @@ export const NavBar = ({ isCompact, onClick, ...rest }: NavBarProps) => {
 
   useEffect(() => {
     wallet?.getFirmwareVersion().then(version => {
-      const [major, minor] = version.replace('v', '').split('.')
-      if (Number(major) >= 7 && Number(minor) >= 6) setSupportsAuthenticator(true)
+      setSupportsAuthenticator(semver.gte(version, '7.6.0'))
     })
   }, [wallet])
 

--- a/packages/keepkey-desktop-app/src/components/Modals/AddAuthenticatorAccount/AddAuthenticatorAccount.tsx
+++ b/packages/keepkey-desktop-app/src/components/Modals/AddAuthenticatorAccount/AddAuthenticatorAccount.tsx
@@ -14,7 +14,7 @@ import type { KeepKeyHDWallet } from '@shapeshiftoss/hdwallet-keepkey'
 import { SlideTransition } from 'components/SlideTransition'
 import { RawText, Text } from 'components/Text'
 // import { SessionTypes } from '@walletconnect/types'
-import { ipcListeners, ipcRenderer } from 'electron-shim'
+import { ipcListeners } from 'electron-shim'
 import { AnimatePresence } from 'framer-motion'
 import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -70,10 +70,7 @@ export const AddAuthenticatorAccountModal = ({ fetchAccs }: ModalProps) => {
     <SlideTransition>
       <Modal
         isOpen={isOpen}
-        onClose={() => {
-          ipcRenderer.send('unlockWindow', {})
-          close()
-        }}
+        onClose={() => close()}
         isCentered
         closeOnOverlayClick={false}
         closeOnEsc={false}

--- a/packages/keepkey-desktop-app/src/components/Modals/ChainSelector/ChainSelector.tsx
+++ b/packages/keepkey-desktop-app/src/components/Modals/ChainSelector/ChainSelector.tsx
@@ -152,7 +152,7 @@ export const ChainSelectorModal = () => {
                             as='button'
                             onClick={() => switchChain(chain)}
                           >
-                            {chain.name} <small>({chain.services[0].latency}ms)</small>
+                            {chain.name} <small>({chain.services[0]?.latency}ms)</small>
                           </Box>
                           <Box alignContent='left'>
                             <small>chainId: {chain.chainId}</small>

--- a/packages/keepkey-desktop-app/src/electron-shim.ts
+++ b/packages/keepkey-desktop-app/src/electron-shim.ts
@@ -1,19 +1,17 @@
-/// <reference types="electron" />
-
 import * as Comlink from 'comlink'
 import { electronEndpoint } from 'comlink-electron-endpoint/renderer'
 
 import type { IpcListeners } from '../../keepkey-desktop/src/types'
 
-const electron = require('electron')
-
-// eslint-disable-next-line import/no-default-export
-export default electron
-
-export const ipcRenderer = electron.ipcRenderer
-
 export const ipcListeners = (() => {
   const { port1, port2 } = new MessageChannel()
-  electron.ipcRenderer.postMessage('@app/get-ipc-listeners', undefined, [port1])
+  window.postMessage(
+    {
+      type: '@app/get-ipc-listeners',
+      payload: port1,
+    },
+    '*',
+    [port1],
+  )
   return Comlink.wrap<IpcListeners>(electronEndpoint(port2))
 })()

--- a/packages/keepkey-desktop-app/src/index.tsx
+++ b/packages/keepkey-desktop-app/src/index.tsx
@@ -4,14 +4,11 @@ import '../../keepkey-desktop/src/comlinkTransferHandlers'
 import { App } from 'App'
 import { AppProviders } from 'AppProviders'
 import { ipcListeners } from 'electron-shim'
-import unhandled from 'electron-unhandled'
 import { renderConsoleArt } from 'lib/consoleArt'
 import { logger } from 'lib/logger'
 import { reportWebVitals } from 'lib/reportWebVitals'
 import React from 'react'
 import { createRoot } from 'react-dom/client'
-
-unhandled()
 
 ipcListeners.appVersion().then(version => {
   ipcListeners.appPreRelease().then(isPreRelease => {

--- a/packages/keepkey-desktop-app/src/loader.ts
+++ b/packages/keepkey-desktop-app/src/loader.ts
@@ -1,12 +1,15 @@
 import 'source-map-support/register'
 
 import { Buffer } from 'buffer'
+// @ts-expect-error
+import * as process from 'process/browser'
 
 import { logger } from './lib/logger'
 ;(async () => {
   globalThis.__dirname = '/'
   globalThis.global = globalThis
   globalThis.Buffer = Buffer
+  globalThis.process = process
   // @ts-expect-error
   globalThis.app_env = await (await fetch('./env.json')).json()
   await import('./index')

--- a/packages/keepkey-desktop-app/src/pages/Authenticator/Authenticator.tsx
+++ b/packages/keepkey-desktop-app/src/pages/Authenticator/Authenticator.tsx
@@ -121,16 +121,19 @@ export const Authenticator = () => {
       )}:${timeRemain}`
       console.log('generateOtp msg: ', msg)
 
-      await wallet
+      const finished = wallet
         .ping({
           msg,
         })
         .catch(console.error)
+
       toast({
         status: 'info',
         title: 'OTP generated',
         description: `Please check the OTP on your keepkey`,
       })
+
+      await finished
     },
     [wallet, toast, supportsFeature],
   )

--- a/packages/keepkey-desktop-app/src/pages/Authenticator/Authenticator.tsx
+++ b/packages/keepkey-desktop-app/src/pages/Authenticator/Authenticator.tsx
@@ -228,9 +228,9 @@ export const Authenticator = () => {
                       accounts.map(acc => (
                         <Tr>
                           <Td>
-                            <Code>
-                              {acc.domain}:{acc.account}
-                            </Code>
+                            <Code>{`${acc.domain.trim() ? `${acc.domain}:` : ''}${
+                              acc.account
+                            }`}</Code>
                           </Td>
                           <Td>
                             <Button

--- a/packages/keepkey-desktop-app/src/pages/Browser/Browser.tsx
+++ b/packages/keepkey-desktop-app/src/pages/Browser/Browser.tsx
@@ -11,7 +11,6 @@ import { Main } from 'components/Layout/Main'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import React, { useCallback, useEffect, useState } from 'react'
 import { FaBug } from 'react-icons/fa'
-import { v4 as uuidv4 } from 'uuid'
 
 const getWebview = () => document.getElementById('webview') as Electron.WebviewTag | null
 
@@ -65,8 +64,6 @@ export const Browser = () => {
   const [webviewReady, setWebviewReady] = useState(false)
   useEffect(() => {
     const webview = getWebview()!
-    webview.setAttribute('autosize', 'on')
-    webview.allowpopups = true
     const listener = () => setWebviewReady(true)
     webview.addEventListener('dom-ready', listener)
     return () => {
@@ -199,6 +196,8 @@ export const Browser = () => {
         style={{
           flexGrow: 1,
         }}
+        autosize={true}
+        allowpopups={true}
       ></webview>
       <Stack direction={{ base: 'column', md: 'column' }} height='full' style={{ margin: '5px' }}>
         {webviewLoadFailure !== undefined && (

--- a/packages/keepkey-desktop-app/src/pages/Browser/Browser.tsx
+++ b/packages/keepkey-desktop-app/src/pages/Browser/Browser.tsx
@@ -1,3 +1,5 @@
+/// <reference types="electron" />
+
 import {
   ArrowForwardIcon,
   ArrowLeftIcon,
@@ -6,7 +8,9 @@ import {
   RepeatIcon,
 } from '@chakra-ui/icons'
 import { Alert, AlertIcon, HStack, IconButton, Input, Stack } from '@chakra-ui/react'
+import * as Comlink from 'comlink'
 import { Main } from 'components/Layout/Main'
+import { ipcListeners } from 'electron-shim'
 // import { WalletActions } from 'context/WalletProvider/actions'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import React, { useCallback, useEffect, useState } from 'react'
@@ -178,6 +182,17 @@ export const Browser = () => {
   //   connectIndirect = connect
   // }, [connect])
 
+  useEffect(() => {
+    if (!webviewReady) return
+
+    const webview = getWebview()!
+    const contentsId = webview.getWebContentsId()
+    const loadURL = webview.loadURL.bind(webview)
+    ipcListeners
+      .webviewAttachOpenHandler(contentsId, Comlink.proxy(loadURL))
+      .catch(e => console.error('webviewAttachOpenHandler error:', e))
+  }, [webviewReady])
+
   return (
     <Main
       height='full'
@@ -196,8 +211,8 @@ export const Browser = () => {
         style={{
           flexGrow: 1,
         }}
-        autosize={true}
-        allowpopups={true}
+        // @ts-expect-error
+        allowpopups='true'
       ></webview>
       <Stack direction={{ base: 'column', md: 'column' }} height='full' style={{ margin: '5px' }}>
         {webviewLoadFailure !== undefined && (

--- a/packages/keepkey-desktop/assets/preload.js
+++ b/packages/keepkey-desktop/assets/preload.js
@@ -1,0 +1,29 @@
+/// <reference types="electron" />
+
+const electron = require('electron')
+// const unhandled = require('electron-unhandled')
+
+window.addEventListener('message', ev => {
+  /** @type unknown */
+  const data = ev.data
+  if (
+    data &&
+    typeof data === 'object' &&
+    'type' in data &&
+    typeof data.type === 'string' &&
+    'payload' in data
+  ) {
+    if (data.type === '@app/get-ipc-listeners' && data.payload instanceof MessagePort) {
+      console.info('preload: forwarding @app/get-ipc-listeners', data)
+      electron.ipcRenderer.postMessage('@app/get-ipc-listeners', undefined, [data.payload])
+    } else if (
+      data.type === '@app/register-render-listeners' &&
+      data.payload instanceof MessagePort
+    ) {
+      console.info('preload: forwarding @app/register-render-listeners', data)
+      electron.ipcRenderer.postMessage('@app/register-render-listeners', undefined, [data.payload])
+    }
+  }
+})
+
+// unhandled()

--- a/packages/keepkey-desktop/assets/splash.html
+++ b/packages/keepkey-desktop/assets/splash.html
@@ -52,7 +52,7 @@
         </div>
 
         <script>
-            const { ipcRenderer, app } = require('electron');
+            const { ipcRenderer } = require('electron');
             const header = document.getElementById('splashText');
             const text = {
                 check: "Checking for updates...",

--- a/packages/keepkey-desktop/src/helpers/utils.ts
+++ b/packages/keepkey-desktop/src/helpers/utils.ts
@@ -69,12 +69,19 @@ export const createMainWindow = async () => {
     backgroundColor: 'white',
     autoHideMenuBar: true,
     webPreferences: {
+      preload: path.join(__dirname, 'assets/preload.js'),
       webviewTag: true,
-      nodeIntegration: true,
-      contextIsolation: false,
       devTools: true,
     },
   })
+  windows.mainWindow.webContents.addListener(
+    'will-attach-webview',
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    (_event, webPreferences, _params) => {
+      // Security check -- we don't use this and it would allow the app to break out of context isolation if compromised
+      delete webPreferences.preload
+    },
+  )
 
   windows.mainWindow.loadURL(`file://${path.join(__dirname, 'app/index.html')}`)
 

--- a/packages/keepkey-desktop/src/helpers/utils.ts
+++ b/packages/keepkey-desktop/src/helpers/utils.ts
@@ -1,5 +1,4 @@
 import { BrowserWindow } from 'electron'
-import isDev from 'electron-is-dev'
 import log from 'electron-log'
 import { rendererIpc } from 'ipcListeners'
 import path from 'path'
@@ -77,9 +76,11 @@ export const createMainWindow = async () => {
   windows.mainWindow.webContents.addListener(
     'will-attach-webview',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    (_event, webPreferences, _params) => {
+    (_event, webPreferences, params) => {
       // Security check -- we don't use this and it would allow the app to break out of context isolation if compromised
       delete webPreferences.preload
+      // Security check -- we don't use this and it would allow the app to disable its CSP if compromised
+      delete params.disablewebsecurity
     },
   )
 

--- a/packages/keepkey-desktop/src/ipcListeners.ts
+++ b/packages/keepkey-desktop/src/ipcListeners.ts
@@ -275,6 +275,33 @@ export const ipcListeners: IpcListeners = {
     })
   },
 
+  async webviewAttachOpenHandler(
+    webContentsId: number,
+    loadUrl: (url: string, options?: Electron.LoadURLOptions) => Promise<void>,
+  ): Promise<void> {
+    console.log(`webviewAttachOpenHandler: subscribing to ${webContentsId}`)
+
+    const contents = webContents.fromId(webContentsId)
+    contents.setWindowOpenHandler((details: Electron.HandlerDetails) => {
+      if (details.disposition === 'foreground-tab') {
+        loadUrl(details.url, {
+          httpReferrer: details.referrer,
+          postData: details.postBody?.data,
+        }).catch(e => console.error('webviewAttachOpenHandler: loadUrl error:', e))
+        return {
+          action: 'deny',
+        }
+      } else {
+        return {
+          action: 'allow',
+          overrideBrowserWindowOptions: {
+            autoHideMenuBar: true,
+          },
+        }
+      }
+    })
+  },
+
   async clearBrowserSession() {
     const browserSession = session.fromPartition('browser')
     await browserSession.clearStorageData()

--- a/packages/keepkey-desktop/src/types.ts
+++ b/packages/keepkey-desktop/src/types.ts
@@ -87,6 +87,11 @@ export type IpcListeners = {
     callback: (data: string) => Promise<void>,
   ): Promise<void>
 
+  webviewAttachOpenHandler(
+    webContentsId: number,
+    loadUrl: (url: string, options?: Electron.LoadURLOptions) => Promise<void>,
+  ): Promise<void>
+
   clearBrowserSession(): Promise<void>
   wipeKeepKey(): Promise<void>
   forceReconnect(): Promise<void>


### PR DESCRIPTION
- fix `window.open()` and `target="_blank"` in the browser -- the former opens a popup window, the latter just opens in the browser
- disable the authenticator button instead of hiding it when the firmware's too old
- enable electron context isolation (helps with the browser fix, and maybe helps keep dapps from hacking your computer)
- update CSPs & silence a few errors