### PR TITLE
remove git clean from the yarn clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "prerec-mac": "brew install git-lfs && git lfs fetch && git lfs install",
     "postinstall": "yaml-sort -i .yarnrc.yml",
-    "clean": "yarn workspaces foreach -p run clean && git clean -fdx",
+    "clean": "yarn workspaces foreach -p run clean",
     "build": "yarn workspaces foreach -pRi --topological-dev --from 'keepkey-desktop' run build",
     "publish": "yarn workspaces foreach -p run publish",
     "release": "yarn run build && yarn workspace keepkey-desktop run release",


### PR DESCRIPTION
`git clean -fdx` should never be hidden in a regular `yarn clean` script. It's only a matter of time before a dev accidentally gets rekt!

```when you run git clean -fdx, you are telling Git to forcefully remove all untracked files and directories, even those ignored by your .gitignore rules. This can be a useful command when you want to clean up your working directory and remove all untracked files and directories that may have accumulated during development or other operations. However, be extremely cautious when using git clean -fdx, as it will permanently delete untracked files, and there is no easy way to recover them once they are removed.```