### PR TITLE
re-implement autologin

### DIFF
--- a/.yarn/cache/@noble-hashes-npm-1.1.2-dbc15bb44d-3c2a8cb7c2.zip
+++ b/.yarn/cache/@noble-hashes-npm-1.1.2-dbc15bb44d-3c2a8cb7c2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb3a7ce35d605c7e3652b5fae88a13b0da20c870d8e2c7b7e4827f55b6272fcc
+size 101595

--- a/.yarn/cache/@noble-secp256k1-npm-1.7.1-95825e0b99-d2301f1f76.zip
+++ b/.yarn/cache/@noble-secp256k1-npm-1.7.1-95825e0b99-d2301f1f76.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f662f6e69d3b3ea90761493325efb69a6aa7612eccc3dee781ac124409319c36
+size 30999

--- a/.yarn/cache/@shapeshiftoss-hdwallet-core-npm-1.41.0-2b1ffb2a1d-0d3ba4a30c.zip
+++ b/.yarn/cache/@shapeshiftoss-hdwallet-core-npm-1.41.0-2b1ffb2a1d-0d3ba4a30c.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f3e6eb9fcb165e3ead26def8a9bc7cb38b5fe269aa27e54850de0160c6b5be7
+size 75095

--- a/.yarn/cache/@shapeshiftoss-hdwallet-walletconnect-npm-1.41.0-379ba9870b-001ad33476.zip
+++ b/.yarn/cache/@shapeshiftoss-hdwallet-walletconnect-npm-1.41.0-379ba9870b-001ad33476.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2bd3924e53dc7a59429112669d16c8552b3e510fa5a4a1f4861c170d49c58b3
+size 43916

--- a/.yarn/cache/ethers-npm-6.6.0-36de8843c5-242f4fb205.zip
+++ b/.yarn/cache/ethers-npm-6.6.0-36de8843c5-242f4fb205.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4bdb3bb85271b651db9fff89de56af775544081d360637557b14f016d6e70b9
+size 3309724

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -46,15 +46,9 @@ packageExtensions:
       axios: ^1.6.0
   '@shapeshiftoss/caip@*':
     dependencies:
-      lodash: 4.17.21
       axios: ^1.6.0
       fs: npm:noist@1.0.0
-  'bs58check@3.0.1':
-    dependencies:
-      bs58: ^4.0.1
-  'bs58check@2.1.2':
-    dependencies:
-      bs58: ^4.0.1
+      lodash: 4.17.21
   '@shapeshiftoss/chain-adapters@10.2.1':
     dependencies:
       '@ethersproject/contracts': ^5.7.0
@@ -187,6 +181,12 @@ packageExtensions:
       assert: ^2.0.0
       buffer: ^6.0.2
       util: ^0.12.5
+  bs58check@2.1.2:
+    dependencies:
+      bs58: ^4.0.1
+  bs58check@3.0.1:
+    dependencies:
+      bs58: ^4.0.1
   chakra-ui-steps@1.8.0:
     dependencies:
       '@chakra-ui/icon': ^3.0.12

--- a/packages/keepkey-desktop-app/.env
+++ b/packages/keepkey-desktop-app/.env
@@ -46,3 +46,4 @@ REACT_APP_ETHEREUM_INFURA_URL2=https://goerli.infura.io/v3/fb05c87983c4431baafd4
 REACT_APP_ETHEREUM_INFURA_URL3=https://avalanche-mainnet.infura.io/v3/fb05c87983c4431baafd4600fd33de7e
 REACT_APP_MIDGARD_URL=https://indexer.thorchain.shapeshift.com/v2
 REACT_APP_WALLET_CONNECT_PROJECT_ID=14d36ca1bc76a70273d44d384e8475ae
+REACT_APP_SHAPESHIFT_DAPP_URL=https://private.shapeshift.com

--- a/packages/keepkey-desktop-app/src/config.ts
+++ b/packages/keepkey-desktop-app/src/config.ts
@@ -53,7 +53,7 @@ const validators = {
   REACT_APP_KEEPKEY_UPDATER_BASE_URL: url(),
   REACT_APP_ETHERSCAN_API_KEY: str(),
   REACT_APP_WALLET_CONNECT_PROJECT_ID: str(),
-  REACT_APP_SHAPESHIFT_DAPP_URL: str({ default: 'https://app.shapeshift.com' }),
+  REACT_APP_SHAPESHIFT_DAPP_URL: str({ default: 'https://private.shapeshift.com' }),
 }
 
 function reporter<T>({ errors }: envalid.ReporterOptions<T>) {

--- a/packages/keepkey-desktop-app/src/pages/Browser/Browser.tsx
+++ b/packages/keepkey-desktop-app/src/pages/Browser/Browser.tsx
@@ -7,7 +7,7 @@ import {
   CloseIcon,
   RepeatIcon,
 } from '@chakra-ui/icons'
-import { Alert, AlertIcon, HStack, IconButton, Input, Stack } from '@chakra-ui/react'
+import { HStack, IconButton, Input, Stack } from '@chakra-ui/react'
 import * as Comlink from 'comlink'
 import { Main } from 'components/Layout/Main'
 import { getConfig } from 'config'
@@ -74,21 +74,17 @@ const checkIfSSDApp = (currentUrl: string) => {
     if (!webview) return
 
     webview
-      .executeJavaScript('localStorage.getItem("@app/serviceKey");', true)
-      .then(apiKey => {
-        if (!apiKey) {
+      .executeJavaScript('localStorage.getItem("@app/ssautologin");', true)
+      .then(ssautologin => {
+        if (!ssautologin) {
           const kkDesktopApiKey = localStorage.getItem('@app/serviceKey')
-          const localWalletType = localStorage.getItem('localWalletType')
           const localWalletDeviceId = localStorage.getItem('localWalletDeviceId')
-          if (!kkDesktopApiKey) return
-          webview
-            .executeJavaScript(
-              `localStorage.setItem("@app/serviceKey", "${kkDesktopApiKey}"); localStorage.setItem("localWalletType", "${localWalletType}"); localStorage.setItem("localWalletDeviceId", "${localWalletDeviceId}");`,
-              true,
-            )
-            .then(() => {
-              webview.reload()
-            })
+          if (!kkDesktopApiKey || !localWalletDeviceId) return
+
+          ipcListeners.getSSAutoLogin(localWalletDeviceId, kkDesktopApiKey).then(
+            injection => webview.executeJavaScript(injection),
+            // .then(() => webview.reload())
+          )
         }
       })
       .catch(console.error)

--- a/packages/keepkey-desktop/assets/preload.js
+++ b/packages/keepkey-desktop/assets/preload.js
@@ -26,4 +26,8 @@ window.addEventListener('message', ev => {
   }
 })
 
+contextBridge.exposeInMainWorld('keepkey', {
+  shapeshiftlogin: () => ipcRenderer.invoke('@app/shapeshift-login'),
+})
+
 // unhandled()

--- a/packages/keepkey-desktop/assets/preload.js
+++ b/packages/keepkey-desktop/assets/preload.js
@@ -26,8 +26,4 @@ window.addEventListener('message', ev => {
   }
 })
 
-contextBridge.exposeInMainWorld('keepkey', {
-  shapeshiftlogin: () => ipcRenderer.invoke('@app/shapeshift-login'),
-})
-
 // unhandled()

--- a/packages/keepkey-desktop/assets/ss_autologin.js
+++ b/packages/keepkey-desktop/assets/ss_autologin.js
@@ -1,0 +1,59 @@
+// Initialized in browser_injection.js
+// const KK_SDK_API_KEY = 'API_KEY_HERE'
+const KK_DEVICE_ID = 'WALLET_DEVICE_ID_HERE'
+
+console.log('LOADED SS AUTOLOGIN SCRIPT')
+
+const openRequest = indexedDB.open('localforage', 2)
+
+openRequest.onupgradeneeded = event => {
+  const db = event.target.result
+  if (!db.objectStoreNames.contains('keyvaluepairs')) {
+    db.createObjectStore('keyvaluepairs')
+  }
+}
+
+openRequest.onsuccess = event => {
+  const db = event.target.result
+  const transaction = db.transaction(['keyvaluepairs'], 'readwrite')
+  const store = transaction.objectStore('keyvaluepairs')
+
+  const getRequest = store.get('persist:root')
+  getRequest.onerror = event => {
+    console.error('Error fetching data:', event.target.error)
+  }
+
+  getRequest.onsuccess = () => {
+    let data = getRequest.result
+    let walletSlice = {}
+
+    if (data) {
+      if (typeof data === 'string') {
+        data = JSON.parse(data)
+      }
+      if (data.localWalletSlice && typeof data.localWalletSlice === 'string') {
+        walletSlice = JSON.parse(data.localWalletSlice)
+      }
+    } else {
+      data = {}
+    }
+
+    walletSlice.walletType = 'keepkey'
+    walletSlice.walletDeviceId = KK_DEVICE_ID
+
+    data.localWalletSlice = JSON.stringify(walletSlice)
+    const updatedData = JSON.stringify(data)
+
+    store.put(updatedData, 'persist:root').onsuccess = () => {
+      console.log('IndexedDB updated with persist:root')
+    }
+  }
+}
+
+openRequest.onerror = event => {
+  console.error('Error opening database:', event.target.errorCode)
+}
+localStorage.setItem('@app/serviceKey', KK_SDK_API_KEY)
+localStorage.setItem('localWalletType', 'keepkey')
+localStorage.setItem('localWalletDeviceId', KK_DEVICE_ID)
+localStorage.setItem('@app/ssautologin', true)

--- a/packages/keepkey-desktop/src/ipcListeners.ts
+++ b/packages/keepkey-desktop/src/ipcListeners.ts
@@ -322,6 +322,14 @@ export const ipcListeners: IpcListeners = {
     return injection.toString().replace('API_KEY_HERE', sdkApiKey)
   },
 
+  async getSSAutoLogin(walletId: string, sdkApiKey: string) {
+    const injection = readFileSync(path.join(__dirname, 'assets/ss_autologin.js'))
+    return injection
+      .toString()
+      .replace('WALLET_DEVICE_ID_HERE', walletId)
+      .replace('API_KEY_HERE', sdkApiKey)
+  },
+
   async clearBrowserSession() {
     const browserSession = session.fromPartition('browser')
     await browserSession.clearStorageData()

--- a/packages/keepkey-desktop/src/types.ts
+++ b/packages/keepkey-desktop/src/types.ts
@@ -100,6 +100,7 @@ export type IpcListeners = {
   setAlwaysOnTop(value: boolean): Promise<void>
   clearLocalStorage(): Promise<void>
   getBrowserInjection(sdkApiKey: string): Promise<string>
+  getSSAutoLogin(walletId: string, sdkApiKey: string): Promise<string>
   getProtocolLaunchUrl(): Promise<string | undefined>
   handleWalletConnectUrlInProtocol(connect: (uri: string) => Promise<void>): Promise<void>
 


### PR DESCRIPTION
Shapeshift dapp now uses `localforage` to store the logged in wallet information, which in turn uses `indexedDB`.
This PR adds a bare bones way to modify the same and add the information needed to auto login into the shapeshift dapp.